### PR TITLE
fix: require feedback before portfolio review submission

### DIFF
--- a/client/src/components/Reviews/PortfolioReview.jsx
+++ b/client/src/components/Reviews/PortfolioReview.jsx
@@ -16,6 +16,10 @@ function PortfolioReview({ candidate, onSubmit ,rounded = "bottom"}) {
         showErrorToast("Oopss","Please rate the candidate")
         return
       }
+      if (!feedback.trim()) {
+        showErrorToast("Oops", "Please enter feedback to proceed");
+        return;
+      }
       onSubmit(candidate._id, {
         jobId: candidate.currentApplication?.jobId ? candidate.currentApplication.jobId  : candidate.jobApplication.jobId ,
         stage: candidate.currentApplication?.currentStage ? candidate.currentApplication.currentStage : candidate.jobApplication.currentStage,
@@ -35,7 +39,13 @@ function PortfolioReview({ candidate, onSubmit ,rounded = "bottom"}) {
           value={feedback}
           onChange={(e) => setFeedback(e.target.value)}
         />
-        <Button variant="icon" onClick={handleSubmit}>Submit</Button>
+        <Button
+          variant="icon"
+          onClick={handleSubmit}
+          disabled={rating < 1 || !feedback.trim()}
+        >
+          Submit
+        </Button>
       </StyledCard>
     );
   };

--- a/client/src/components/Staging/StageRating.jsx
+++ b/client/src/components/Staging/StageRating.jsx
@@ -67,6 +67,10 @@ function StageRating({customSchema,candidateId,jobId,name,candidate,onSubmit,sta
           return
         }
       }
+      if (!feedback.trim()) {
+        showErrorToast("Oops", "Please enter feedback to proceed");
+        return;
+      }
       onSubmit(candidate._id, {
         jobId: candidate.currentApplication?.jobId ? candidate.currentApplication.jobId  : candidate.jobApplication.jobId ,
         stage: candidate.currentApplication?.currentStage ? candidate.currentApplication.currentStage : candidate.jobApplication.currentStage,
@@ -125,7 +129,7 @@ function StageRating({customSchema,candidateId,jobId,name,candidate,onSubmit,sta
                 value={feedback}
                 onChange={(e) => setFeedback(e.target.value)}
               />
-              <Button variant="icon" onClick={handleSubmit} disabled={feedback.length < 50 || Object.entries(rating).some(([key, value]) => key !== "Budget" && value === 0)}>Submit</Button>
+              <Button variant="icon" onClick={handleSubmit} disabled={!feedback.trim() || Object.entries(rating).some(([key, value]) => key !== "Budget" && value === 0)}>Submit</Button>
             </div>
           </div>
           </>
@@ -142,7 +146,7 @@ function StageRating({customSchema,candidateId,jobId,name,candidate,onSubmit,sta
                 value={feedback}
                 onChange={(e) => setFeedback(e.target.value)}
               />
-              <Button variant="icon" onClick={handleSubmit} disabled={rating < 1 || feedback.length < 50}>Submit</Button>
+              <Button variant="icon" onClick={handleSubmit} disabled={rating < 1 || !feedback.trim()}>Submit</Button>
             </div>
           </div>
           </>}

--- a/server/controllers/admin/dr.controller.js
+++ b/server/controllers/admin/dr.controller.js
@@ -583,6 +583,15 @@ export const autoAssignPortfolios = async (req, res) => {
      if (!candidateId || !jobId || !stage) {
        return res.status(400).json({ message: 'candidateId, jobId, and stage are required' });
      }
+
+     if (stage === 'Portfolio') {
+       if (!ratings || (typeof ratings === 'number' && ratings < 1)) {
+         return res.status(400).json({ message: 'Please rate the candidate' });
+       }
+       if (!feedback || !String(feedback).trim()) {
+         return res.status(400).json({ message: 'Please enter feedback to proceed' });
+       }
+     }
  
      // Find the candidate by ID
      const candidate = await candidates.findById(candidateId);
@@ -644,7 +653,11 @@ export const autoAssignPortfolios = async (req, res) => {
         const additional = stageStatus.additionalReviewers || [];
         if (additional.length > 0) {
           const hasScores = additional.every(
-            (rev) => rev.score !== undefined && rev.score !== null
+            (rev) =>
+              rev.score !== undefined &&
+              rev.score !== null &&
+              rev.feedback &&
+              String(rev.feedback).trim()
           );
           if (hasScores) {
             const primaryScore =


### PR DESCRIPTION
Disable submit on the design reviewer Reviews page until feedback is provided, and reject score-only portfolio submissions on the backend to prevent false success responses.